### PR TITLE
parsing the gpt3 response locally with regex

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,4 @@
 modal-client
 openai
 flask
-ray
 flask-cors

--- a/backend/server.py
+++ b/backend/server.py
@@ -45,18 +45,18 @@ Output the API response as json prefixed with '!API response!:'. Then output the
     completion = json.loads(completion)["text"]
 
     # parsing "API Response" and "New Database State" with regex
-    future1 = re.search("(?<=!API Response!:).*(?=!New Database State!:)", completion, re.DOTALL)
-    future2 = re.search("(?<=!New Database State!:).*", completion, re.DOTALL)
+    api_response_match = re.search("(?<=!API Response!:).*(?=!New Database State!:)", completion, re.DOTALL)
+    new_database_match = re.search("(?<=!New Database State!:).*", completion, re.DOTALL)
 
-    # converting regex result into json
-    api_response = future1.string[future1.regs[0][0]:future1.regs[0][1]].strip()
-    new_database = future2.string[future2.regs[0][0]:future2.regs[0][1]].strip()
+    # converting regex result into json string
+    api_response_text = api_response_match.string[api_response_match.regs[0][0]:api_response_match.regs[0][1]].strip()
+    new_database_text = new_database_match.string[new_database_match.regs[0][0]:new_database_match.regs[0][1]].strip()
 
-    response = json.loads(json.dumps(ast.literal_eval(api_response)))
+    response = json.loads(json.dumps(ast.literal_eval(api_response_text)))
     print("RESPONSE")
     print(response)
 
-    new_state = json.loads(json.dumps(ast.literal_eval(new_database)))
+    new_state = json.loads(json.dumps(ast.literal_eval(new_database_text)))
     print("NEW_STATE")
     print(new_state)
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,13 +1,10 @@
 import json
 from flask import Flask
-import ray
-ray.init()
 from flask_cors import CORS
 import requests
 import re
 import ast
 
-@ray.remote
 def gpt3(input):
     response = requests.post(
     "https://dashboard.scale.com/spellbook/api/app/kw1n3er6",
@@ -41,7 +38,7 @@ Database State:
 
 Output the API response as json prefixed with '!API response!:'. Then output the new database state as json, prefixed with '!New Database State!:'. If the API call is only requesting data, then don't change the database state, but base your 'API Response' off what's in the database.
 """
-    completion = ray.get(gpt3.remote(gpt3_input))
+    completion = gpt3(gpt3_input)
     completion = json.loads(completion)["text"]
 
     # parsing "API Response" and "New Database State" with regex

--- a/backend/server.py
+++ b/backend/server.py
@@ -4,6 +4,8 @@ import ray
 ray.init()
 from flask_cors import CORS
 import requests
+import re
+import ast
 
 @ray.remote
 def gpt3(input):
@@ -37,19 +39,27 @@ API Call (indexes are zero-indexed):
 Database State:
 {db[app_name]["state"]}
 
-Output the API response prefixed with 'API response:'. Then output the new database state as json, prefixed with 'New Database State:'. If the API call is only requesting data, then don't change the database state, but base your 'API Response' off what's in the database.
+Output the API response as json prefixed with '!API response!:'. Then output the new database state as json, prefixed with '!New Database State!:'. If the API call is only requesting data, then don't change the database state, but base your 'API Response' off what's in the database.
 """
     completion = ray.get(gpt3.remote(gpt3_input))
     completion = json.loads(completion)["text"]
 
-    future1 = gpt3.remote(f"{completion}\n\nAPI Response as valid json (as above, ignoring new database state): ")
-    future2 = gpt3.remote(f"{completion}\n\nThe value of 'New Database State' above (as json):")
-    response = json.loads(ray.get(future1).strip())["text"].strip()
+    # parsing "API Response" and "New Database State" with regex
+    future1 = re.search("(?<=!API Response!:).*(?=!New Database State!:)", completion, re.DOTALL)
+    future2 = re.search("(?<=!New Database State!:).*", completion, re.DOTALL)
+
+    # converting regex result into json
+    api_response = future1.string[future1.regs[0][0]:future1.regs[0][1]].strip()
+    new_database = future2.string[future2.regs[0][0]:future2.regs[0][1]].strip()
+
+    response = json.loads(json.dumps(ast.literal_eval(api_response)))
     print("RESPONSE")
     print(response)
-    new_state = json.loads(json.loads(ray.get(future2).strip())["text"].strip())
+
+    new_state = json.loads(json.dumps(ast.literal_eval(new_database)))
     print("NEW_STATE")
     print(new_state)
+
     db[app_name]["state"] = new_state
     json.dump(db, open('db.json', 'w'), indent=4, default=dict_to_json)
     return response


### PR DESCRIPTION
I saw that in `server.py` you are making 3 requests to gpt. I thought that is a bit slow and wasteful considering the free credits limit. With my changes you will only need to make a single gpt request for each flask api request.

Note: the `ast.literal_eval` is a limited form of eval and will accept only a very limited set of instructions. This should make this unproblematic.